### PR TITLE
Make xmr-sample-app windows compatible

### DIFF
--- a/bin/build_browser_app.bat
+++ b/bin/build_browser_app.bat
@@ -1,0 +1,23 @@
+ECHO OFF
+
+rem delete contents of old browser build
+IF EXIST browser_build (
+rmdir /s /q browser_build
+) ELSE (
+mkdir browser_build
+)
+
+rem build browser tests
+call npm run build_browser_app_windows
+
+rem copy dependencies to browser build
+copy node_modules\monero-javascript\dist\monero_core.js browser_build\monero_core.js
+copy node_modules\monero-javascript\dist\monero_core.wasm browser_build\monero_core.wasm
+copy node_modules\monero-javascript\dist\monero_core_keys.js browser_build\monero_core_keys.js
+copy node_modules\monero-javascript\dist\monero_core_keys.wasm browser_build\monero_core_keys.wasm
+copy node_modules\monero-javascript\dist\MoneroWebWorker.dist.js browser_build\MoneroWebWorker.dist.js
+copy node_modules\monero-javascript\dist\MoneroWebWorker.dist.js.map browser_build\MoneroWebWorker.dist.js.map
+xcopy src browser_build
+
+rem start server
+bin\start_dev_server.bat

--- a/bin/build_browser_app.sh
+++ b/bin/build_browser_app.sh
@@ -5,7 +5,7 @@ mkdir -p ./browser_build/ || exit 1
 rm -r ./browser_build/ || exit 1
 
 # build browser tests
-npm run build_browser_app || exit 1
+npm run build_browser_app_unix || exit 1
 
 # copy dependencies to browser build
 cp node_modules/monero-javascript/dist/monero_core.js browser_build/monero_core.js

--- a/bin/start_dev_server.bat
+++ b/bin/start_dev_server.bat
@@ -1,0 +1,3 @@
+cd browser_build
+..\bin\run_server.py
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Client-side Monero web wallet",
   "main": "src/index.js",
   "scripts": {
-    "build_browser_app": "webpack --config ./webpack.config.js",
+    "build_browser_app_unix": "webpack --config ./webpack.config.js",
+    "build_browser_app_windows": "webpack --config .\\webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
*Add batch scripts
*Modify package.json build_web_app script - split into separate windows and unix scripts

Fix changes to package.json

Fix build_browser_app.sh to reflect change to package.json scripts: Change "npm run build_browser_app" to "npm run build_browser_app_unix"